### PR TITLE
ci(project): make Set Component step continue-on-error (Phase 3 fix)

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -60,6 +60,7 @@ jobs:
       # template stays a drop-in for any repo even before the variable
       # is registered).
       - name: Set Component field
+        continue-on-error: true
         if: vars.TALKEN_COMPONENT != ''
         env:
           GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
Phase 2 was fail-fast under `set -e`; without the right PAT scopes the whole job failed and Phase 3 (auto-assign) never ran. Marks the step `continue-on-error: true` so Phase 3 stays independent.